### PR TITLE
Make X11 Fully Optional

### DIFF
--- a/libs/thelib++/CMakeLists.txt
+++ b/libs/thelib++/CMakeLists.txt
@@ -35,6 +35,8 @@ project(TheLib)
 
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 
+find_package(X11)
+
 # Gather header files and store the result in the variable header_files
 # Find the files relative to the directory of this cmake file
 file(GLOB_RECURSE header_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "include/*.h")
@@ -63,6 +65,11 @@ list(REMOVE_ITEM source_files
 	"src/system/net/simple_message_dispatcher.cpp"
 	)
 
+if(NOT X11_FOUND)
+    list(REMOVE_ITEM source_files
+         "src/graphics/x11_window_behaviour.cpp"
+        )
+endif()
 
 # Set the include directory to point to the subdirectory "include"
 include_directories("include")

--- a/libs/vislib/sys/CMakeLists.txt
+++ b/libs/vislib/sys/CMakeLists.txt
@@ -10,7 +10,12 @@ endif()
 
 set(CMAKE_THREAD_PREFER_PTHREAD)
 find_package(Threads REQUIRED)
-find_package(X11 REQUIRED)
+
+find_package(X11)
+if(X11_FOUND)
+    add_definitions(-DUSE_X11)
+endif(X11_FOUND)
+
 find_package(Curses REQUIRED)
 
 
@@ -32,6 +37,7 @@ include_directories("include" "src"
 
 # target definition
 add_library(vislibsys${BITS} STATIC ${header_files} ${source_files})
-target_link_libraries(vislibsys${BITS} ${CMAKE_THREAD_LIBS_INIT} ${X11_LIBRARIES} ${CURSES_LIBRARIES} -lrt -lcrypt)
+target_link_libraries(vislibsys${BITS} ${CMAKE_THREAD_LIBS_INIT} ${CURSES_LIBRARIES} -lrt -lcrypt)
+#target_link_libraries(vislibsys${BITS} ${CMAKE_THREAD_LIBS_INIT} ${X11_LIBRARIES} ${CURSES_LIBRARIES} -lrt -lcrypt)
 
 

--- a/libs/vislib/sys/include/vislib/SystemInformation.h
+++ b/libs/vislib/sys/include/vislib/SystemInformation.h
@@ -13,7 +13,7 @@
 #pragma managed(push, off)
 #endif /* defined(_WIN32) && defined(_MANAGED) */
 
-#ifndef _WIN32
+#if (!defined(_WIN32) && defined(USE_X11))
 #include <X11/Xlib.h>
 #endif /* !_WIN32 */
 
@@ -346,7 +346,7 @@ namespace sys {
             HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData);
 #endif /* _WIN32 */
 
-#ifndef _WIN32
+#if (!defined(_WIN32) && defined(USE_X11))
         /**
          * Open the root window of the specified X11 screen and answer its 
          * location and dimension.

--- a/libs/vislib/sys/src/MessageBox.cpp
+++ b/libs/vislib/sys/src/MessageBox.cpp
@@ -9,12 +9,14 @@
 #include "vislib/MessageBox.h"
 #include "vislib/IllegalStateException.h"
 #include "vislib/MissingImplementationException.h"
-#ifndef _WIN32
+#if (!defined(_WIN32) && defined(USE_X11))
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xos.h>
 #include <X11/keysym.h>
 #include <X11/keysymdef.h>
+#endif
+#ifndef _WIN32
 #include <stdio.h>
 #include <stdlib.h>
 #endif /* !_WIN32 */
@@ -31,7 +33,7 @@
 #endif /* _WIN32 */
 
 
-#ifndef _WIN32
+#if (!defined(_WIN32) && defined(USE_X11))
 namespace vislib {
 namespace sys {
 namespace MessageBoxLinuxUtils {
@@ -997,7 +999,8 @@ vislib::sys::MessageBox::ShowDialog(void) {
         default: this->retval = RET_NONE; break;
     }
 
-#else /* _WIN32 */
+#endif
+#if (!defined(_WIN32) && defined(USE_X11))
 
     Display *display;           // the display
     int screen;                 // the screen

--- a/libs/vislib/sys/src/SystemInformation.cpp
+++ b/libs/vislib/sys/src/SystemInformation.cpp
@@ -193,8 +193,8 @@ DWORD vislib::sys::SystemInformation::MonitorRects(
             reinterpret_cast<LPARAM>(&outMonitorRects))) {
         throw SystemException(__FILE__, __LINE__);
     }
-
-#else /* _WIN32 */
+#endif
+#if (!defined(_WIN32) && defined(USE_X11))
     int cntScreens = 0;         // # of attached screens.
     Display *dpy = NULL;        // The display.
     StringA errorDesc;          // For formatting an error message.
@@ -309,7 +309,8 @@ vislib::sys::SystemInformation::PrimaryMonitorRect(void) {
         throw SystemException(ERROR_NOT_FOUND, __FILE__, __LINE__);
     }
 
-#else /* _WIN32 */
+#endif
+#if (!defined(_WIN32) && defined(USE_X11))
     Display *dpy = NULL;
     StringA errorDesc;
 
@@ -650,7 +651,7 @@ BOOL CALLBACK vislib::sys::SystemInformation::calcVirtualScreenProc(
 #endif /* _WIN32 */
 
 
-#ifndef _WIN32
+#if (!defined(_WIN32) && defined(USE_X11))
 /*
  * vislib:sys::SystemInformation::getRootWndRect
  */


### PR DESCRIPTION
I was trying to compile Rivlib again in a debian minimal system and noticed there are still some X11 dependencies lacking in `Vislib` and `TheLib++`.

The two attached patches should fix that problem.
